### PR TITLE
Fixes json serialization of metrics.

### DIFF
--- a/src/main/scala/github/gphat/datadog/Client.scala
+++ b/src/main/scala/github/gphat/datadog/Client.scala
@@ -62,7 +62,13 @@ class Client(
   def addMetrics(series: Seq[Metric]): Future[Response] = {
 
     val json = (
-      "series" -> series
+      "series" -> series.map { s =>
+        ("metric" -> s.name) ~
+        ("points" -> s.points.map(tuple => Seq(JInt(tuple._1), JDouble(tuple._2)))) ~
+        ("metric_type" -> s.metricType) ~
+        ("tags" -> s.tags) ~
+        ("host" -> s.host)
+      }
     )
 
     val path = Seq("series").mkString("/")

--- a/src/test/scala/MetricSpec.scala
+++ b/src/test/scala/MetricSpec.scala
@@ -54,12 +54,21 @@ class MetricSpec extends Specification {
       val body = parse(adapter.getRequest.get.entity.asString)
       val names = for {
         JObject(series) <- body
-        JField("name", JString(name)) <- series
+        JField("metric", JString(name)) <- series
       } yield name
 
       names must have size(2)
       names must contain(be_==("foo.bar.test")).exactly(1)
       names must contain(be_==("foo.bar.gorch")).exactly(1)
+
+      val points = for {
+        JObject(series) <- body
+        JField("points", JArray(point)) <- series
+      } yield point
+
+      points must have size(2)
+      points must contain(be_==(Seq(JArray(List(JInt(1412183578), JDouble(12.0))), JArray(List(JInt(1412183579), JDouble(123.0)))))).exactly(1)
+      points must contain(be_==(Seq(JArray(List(JInt(1412183580), JDouble(12.0))), JArray(List(JInt(1412183581), JDouble(123.0)))))).exactly(1)
 
       adapter.getRequest must beSome.which(_.method == HttpMethods.POST)
     }


### PR DESCRIPTION
Ensure that a Metric is serialized to the right JSON representation.
Specifically, `name` -> `metric` and converting the `points` tuple to
an array to match the spec.
