### PR TITLE
[CDP-1443] Bump json4s version to match AIQ and Spark

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,9 +24,11 @@ libraryDependencies += "io.spray" %% "spray-httpx" % "1.3.2"
 
 libraryDependencies += "io.spray" %% "spray-util" % "1.3.2"
 
-libraryDependencies += "org.json4s" %% "json4s-native" % "3.5.0"
+libraryDependencies += "org.json4s" %% "json4s-native" % "3.5.3"
 
-libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.5.0"
+libraryDependencies += "org.json4s" %% "json4s-core" % "3.5.3"
+
+libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.5.3"
 
 libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.5.26"
 

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ libraryDependencies += "org.json4s" %% "json4s-native" % "3.5.0"
 
 libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.5.0"
 
-libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.3.2"
+libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.5.26"
 
 libraryDependencies += "org.clapper" %% "grizzled-slf4j" % "1.0.2"
 
@@ -36,8 +36,8 @@ libraryDependencies += "org.specs2" %% "specs2-core" % "3.0.1" % "test"
 
 libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.7.6" % "test"
 
-releasePublishArtifactsAction := PgpKeys.publishSigned.value
-
 releaseCrossBuild := true
 
 Publish.settings
+
+publishTo := Some(Resolver.file("file", new File("/tmp/fck")))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.15

--- a/src/main/scala/github/gphat/datadog/HttpAdapter.scala
+++ b/src/main/scala/github/gphat/datadog/HttpAdapter.scala
@@ -99,7 +99,7 @@ class HttpAdapter(
     (IO(Http) ? Http.CloseAll) onComplete {
       // When this completes we will shutdown the actor system if it wasn't
       // supplied by the user.
-      case Success(x) => if (actorSystem.isEmpty) { finalAS.shutdown() }
+      case Success(x) => if (actorSystem.isEmpty) { finalAS.terminate() }
       // If we fail to close not sure what we can except rethrow
       case Failure(t) => throw t
     }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.1-SNAPSHOT"
+version in ThisBuild := "1.2.2-SNAPSHOT"


### PR DESCRIPTION
When testing Spark 2.4, I'm seeing this error in compile 

```
2021-05-13T20:41:06.975-0500 WARN [main] MetricClient  c= - StatsD metrics disabled in config.
java.lang.NoSuchMethodError: org.json4s.FieldSerializer.<init>(Lscala/PartialFunction;Lscala/PartialFunction;Lscala/reflect/Manifest;)V
	at github.gphat.datadog.Client.<init>(Client.scala:20)
	at co.actioniq.clients.datadog.DDClient.<init>(DDClient.scala:30)
	at co.actioniq.clients.datadog.DDAppClient.<init>(DDClient.scala:67)
	at co.actioniq.clients.datadog.DataDogApiClient$.apply(DataDogApiClient.scala:348)
```

I noticed gphat is using json4s 3.5.0 but AIQ references 3.2.11 and Spark references 3.5.3. I tried to force 3.5 on the AIQ side but it didnt work, so now I'm just trying to enforce 3.5.3 in all places.

### Test Plan
🤷 

### Deploy
`sbt publishLocal` and then copy it up to `s3://aiq-artifacts/releases/.../`